### PR TITLE
Update BookmarkedGambit.php

### DIFF
--- a/src/Gambits/BookmarkedGambit.php
+++ b/src/Gambits/BookmarkedGambit.php
@@ -18,7 +18,7 @@ class BookmarkedGambit extends AbstractRegexGambit
         $actor = $search->getActor();
 
         $method = $negate ? 'whereNotIn' : 'whereIn';
-        $search->getQuery()->$method('id', function (Builder $query) use ($actor) {
+        $search->getQuery()->$method('discussions.id', function (Builder $query) use ($actor) {
             $query->select('discussion_id')
                 ->from('discussion_user')
                 ->where('user_id', $actor->id)


### PR DESCRIPTION
I add a filter mutator to DiscussionFilterer in my extension. In the mutator I left join another table and it will show the error "Integrity constraint violation: 1052 Column 'id' in IN/ALL/ANY subquery is ambiguous". I found out if I changed the 'id' to 'discussions.id' will solve the issue.